### PR TITLE
Dltp 1197 incorporate figaro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 gem 'capistrano', '~> 3.5.0'
 gem 'capistrano-bundler'
 gem 'coffee-rails', '~> 4.2'
+gem 'figaro'
 gem 'jbuilder', '~> 2.5'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffi (1.9.18)
+    figaro (1.1.1)
+      thor (~> 0.14)
     flipflop (2.3.1)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -777,6 +779,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.6)
   fcrepo_wrapper
+  figaro
   hyrax (= 2.0.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 [CurateND](https://curate.nd.edu) on [Hyrax](http://github.com/samvera/hyrax/). RAWR!
 
+## Secret Management
+
+Instead of the Rails convention of config/secrets.yml, Curax leverages [Figaro](https://github.com/laserlemon/figaro).
+
+There are two primary files for Figaro:
+
+* [config/application.yml](./config/application.yml)
+* [config/initializers/figaro_required_env_variables.rb](./config/initializers/figaro_required_env_variables.rb)
+
+**NOTE: These files are checked into the repository, so do not include any "live" values of sensitive nature (e.g. passwords).**
+You will need to add those values to the associated secrets repository. See [scripts/update_secrets.sh](./scripts/update_secrets.sh) for details on adding those secrets.
+
 ## Running Locally
 
 1. Install Postres (assumes [Homebrew](https://brew.sh/))

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ There are two primary files for Figaro:
 **NOTE: These files are checked into the repository, so do not include any "live" values of sensitive nature (e.g. passwords).**
 You will need to add those values to the associated secrets repository. See [scripts/update_secrets.sh](./scripts/update_secrets.sh) for details on adding those secrets.
 
+When defining secrets for this repository (via [config/application.yml](./config/application.yml)):
+
+* You may commit "secret" keys for test and development. These keys will be world-wide visible, so consider the impact of them being known to the public.
+* For other environments (e.g. staging, production, etc), you can define those secrets in the respective secret storage.
+
+Many upstream dependencies create their configurations to have a top-level key of the RAILS_ENV. The assumption is that for each of the possible RAILS_ENV, we will add top-level keys to their associated YML file. See [config/blacklight.yml](./config/blacklight.yml) and [config/database.yml](./config/database.yml) for examples
+
 ## Running Locally
 
 1. Install Postres (assumes [Homebrew](https://brew.sh/))

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,15 +1,30 @@
 # *****************************************************************************
-#
-# NOTE: Unlike the standard Figaro implementation this configuration file is
-# checked into the repository.
-#
-# As such only include "dummy values" or those values necessary for booting in
-# development mode.
-#
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
 # *****************************************************************************
 #
-# The purpose of the config/application.yml is to define additional ENV
-# variables that are injected into the Rails application.
+#
+# DEVELOPERS: Figaro allows for defining ENV variables that span Rails
+#             environments. Do not do this. For each Rails environment scope
+#             the ENV to that environment; And do not include other Rails
+#             environments in the Figaro definition.
+#
+#             In other words, when you are creating the secrets for the Staging
+#             Rails environment, do not include other Rails environments. To do
+#             so would mean for that installation that you could run the app
+#             in that Rails environment; I never want to allow runing the
+#             production app using the development Rails environment.
+#
+#             Also, do not include in this file sensitive information that
+#             could be leveraged in a WWW context.
+#
+# Unlike the standard Figaro implementations this configuration file is
+# checked into the repository. The allowed RAILS_ENVs are development and test.
+# Those environments are what developers run on their local installations. The
+# secrets that are included demonstrate how you would configure secrets for the
+# other environments.
 #
 # The applicatino's ENV variables first come from the ENV of the shell profile,
 # then any missing ENV variables are injected via the config/application.yml
@@ -17,21 +32,17 @@
 #
 # See https://github.com/laserlemon/figaro for further details on usage
 #
-# Add configuration values here, as shown below. Also add those keys to
-# config/initializers/figaro_required_env_variables.rb
 #
-# pusher_app_id: "2954"
-# pusher_key: 7381a978f7dd7f9a1117
-# pusher_secret: abdc3b896a0ffb85d373
-# stripe_api_key: sk_test_2J0l093xOyW72XUYJHE4Dv2r
-# stripe_publishable_key: pk_test_ro9jV5SNwGb1yYlQfzG17LHK
-#
-# production:
-#   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
-#   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
+# *****************************************************************************
 
 development:
   application_database_name: curax_development
+  application_database_host: localhost
   blacklight_adapter: solr
   cable_adapter: async
   devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54
@@ -46,6 +57,7 @@ development:
 
 test:
   application_database_name: curax_test
+  application_database_host: localhost
   blacklight_adapter: solr
   cable_adapter: async
   devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,31 @@
+# *****************************************************************************
+#
+# NOTE: Unlike the standard Figaro implementation this configuration file is
+# checked into the repository.
+#
+# As such only include "dummy values" or those values necessary for booting in
+# development mode.
+#
+# *****************************************************************************
+#
+# The purpose of the config/application.yml is to define additional ENV
+# variables that are injected into the Rails application.
+#
+# The applicatino's ENV variables first come from the ENV of the shell profile,
+# then any missing ENV variables are injected via the config/application.yml
+# file.
+#
+# See https://github.com/laserlemon/figaro for further details on usage
+#
+# Add configuration values here, as shown below. Also add those keys to
+# config/initializers/figaro_required_env_variables.rb
+#
+# pusher_app_id: "2954"
+# pusher_key: 7381a978f7dd7f9a1117
+# pusher_secret: abdc3b896a0ffb85d373
+# stripe_api_key: sk_test_2J0l093xOyW72XUYJHE4Dv2r
+# stripe_publishable_key: pk_test_ro9jV5SNwGb1yYlQfzG17LHK
+#
+# production:
+#   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
+#   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU

--- a/config/application.yml
+++ b/config/application.yml
@@ -29,3 +29,31 @@
 # production:
 #   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
 #   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+
+development:
+  application_database_name: curax_development
+  blacklight_adapter: solr
+  cable_adapter: async
+  devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54
+  fedora_base_path: /dev
+  fedora_password: fedoraAdmin
+  fedora_url: http://127.0.0.1:8984/rest
+  fedora_username: fedoraAdmin
+  redis_host: localhost
+  redis_port: '6379'
+  secret_key_base: 30fe58c029e2f851db78db03cc60677ae46d582695b0db61a6e9d20a690aed94f4aad6428e756bcfe5ab85182e5474cef31140916587238c580456973e9c8684
+  solr_url: http://127.0.0.1:8983/solr/hydra-development
+
+test:
+  application_database_name: curax_test
+  blacklight_adapter: solr
+  cable_adapter: async
+  devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54
+  fedora_base_path: /dev
+  fedora_password: fedoraAdmin
+  fedora_url: http://127.0.0.1:8986/rest
+  fedora_username: fedoraAdmin
+  redis_host: localhost
+  redis_port: '6379'
+  secret_key_base: 30fe58c029e2f851db78db03cc60677ae46d582695b0db61a6e9d20a690aed94f4aad6428e756bcfe5ab85182e5474cef31140916587238c580456973e9c8684
+  solr_url: http://127.0.0.1:8985/solr/hydra-test

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -4,3 +4,6 @@ development:
 test:
   adapter: <%= Figaro.env.blacklight_adapter %>
   url: <%= Figaro.env.solr_url %>
+staging:
+  adapter: <%= Figaro.env.blacklight_adapter %>
+  url: <%= Figaro.env.solr_url %>

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,6 @@
 development:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
-test: &test
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
-production:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  adapter: <%= Figaro.env.blacklight_adapter %>
+  url: <%= Figaro.env.solr_url %>
+test:
+  adapter: <%= Figaro.env.blacklight_adapter %>
+  url: <%= Figaro.env.solr_url %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,10 @@
 development:
-  adapter: async
+  adapter: <%= Figaro.env.cable_adapter %>
 
 test:
-  adapter: async
+  adapter: <%= Figaro.env.cable_adapter %>
 
-production:
-  adapter: redis
-  url: redis://localhost:6379/1
-  channel_prefix: curax_production
+# production:
+#   adapter: <%= Figaro.env.cable_adapter %>
+#   url: <%= Figaro.env.cable_adapter_url %>
+#   channel_prefix: <%= Figaro.env.cable_adapter_channel_prefix %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,6 +4,9 @@ development:
 test:
   adapter: <%= Figaro.env.cable_adapter %>
 
+staging:
+  adapter: <%= Figaro.env.cable_adapter %>
+
 # production:
 #   adapter: <%= Figaro.env.cable_adapter %>
 #   url: <%= Figaro.env.cable_adapter_url %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,66 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  database: <%= Figaro.env.application_database_name! %>
 
 development:
   <<: *default
-  database: curax_development
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: curax
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: curax_test
-
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
-production:
-  <<: *default
-  database: curax_production
-  username: curax
-  password: <%= ENV['CURAX_DATABASE_PASSWORD'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,9 +21,15 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   database: <%= Figaro.env.application_database_name! %>
+  host: <%= Figaro.env.application_database_host! %>
+<% if Figaro.env.application_database_username.present? %>  username: <%= Figaro.env.application_database_username %><% end %>
+<% if Figaro.env.application_database_password.present? %>  password: <%= Figaro.env.application_database_password %><% end %>
 
 development:
   <<: *default
 
 test:
+  <<: *default
+
+staging:
   <<: *default

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,15 +1,10 @@
 development:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
-  base_path: /dev
+  user: <%= Figaro.env.fedora_username %>
+  password: <%= Figaro.env.fedora_password %>
+  url: <%= Figaro.env.fedora_url %>
+  base_path: <%= Figaro.env.fedora_base_path %>
 test:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
-  base_path: /test
-production:
-  user: fedoraAdmin
-  password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
-  base_path: /prod
+  user: <%= Figaro.env.fedora_username %>
+  password: <%= Figaro.env.fedora_password %>
+  url: <%= Figaro.env.fedora_url %>
+  base_path: <%= Figaro.env.fedora_base_path %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -8,3 +8,8 @@ test:
   password: <%= Figaro.env.fedora_password %>
   url: <%= Figaro.env.fedora_url %>
   base_path: <%= Figaro.env.fedora_base_path %>
+staging:
+  user: <%= Figaro.env.fedora_username %>
+  password: <%= Figaro.env.fedora_password %>
+  url: <%= Figaro.env.fedora_url %>
+  base_path: <%= Figaro.env.fedora_base_path %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-   config.secret_key = '42843c4e093790d90bb0baf994c17ec6d25d9c6c0d21763a0495ffaa2b724e4409dcf36355d8302723f47f420df6fd87b042711085482494471a3afc56ee5618'
+   config.secret_key = Figaro.env.devise_secret_key!
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/figaro_required_env_variables.rb
+++ b/config/initializers/figaro_required_env_variables.rb
@@ -6,3 +6,19 @@
 # file.
 #
 # See https://github.com/laserlemon/figaro for further details on usage
+
+# Please keep these alphabetized!
+Figaro.require_keys(
+  'application_database_name',
+  'blacklight_adapter',
+  'cable_adapter',
+  'devise_secret_key',
+  'fedora_base_path',
+  'fedora_password',
+  'fedora_url',
+  'fedora_username',
+  'redis_host',
+  'redis_port',
+  'secret_key_base',
+  'solr_url'
+)

--- a/config/initializers/figaro_required_env_variables.rb
+++ b/config/initializers/figaro_required_env_variables.rb
@@ -1,0 +1,8 @@
+# The purpose of this initializer it to define which ENV variables are
+# expected by this Rails application.
+#
+# The applicatino's ENV variables first come from the ENV of the shell profile,
+# then any missing ENV variables are injected via the config/application.yml
+# file.
+#
+# See https://github.com/laserlemon/figaro for further details on usage

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -4,3 +4,6 @@ development:
 test:
   host: <%= Figaro.env.redis_host %>
   port: <%= Figaro.env.redis_port.to_i %>
+staging:
+  host: <%= Figaro.env.redis_host %>
+  port: <%= Figaro.env.redis_port.to_i %>

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,9 +1,6 @@
 development:
-  host: localhost
-  port: 6379
+  host: <%= Figaro.env.redis_host %>
+  port: <%= Figaro.env.redis_port.to_i %>
 test:
-  host: localhost
-  port: 6379
-production:
-  host: localhost
-  port: 6379
+  host: <%= Figaro.env.redis_host %>
+  port: <%= Figaro.env.redis_port.to_i %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,3 +6,6 @@ development:
 
 test:
   secret_key_base: <%= Figaro.env.secret_key_base %>
+
+staging:
+  secret_key_base: <%= Figaro.env.secret_key_base %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,32 +1,8 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key is used for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rails secret` to generate a secure secret key.
-
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
-
-# Shared secrets are available across all environments.
-
-# shared:
-#   api_key: a1B2c3D4e5F6
-
-# Environmental secrets are only available for that specific environment.
+# Welcome Rails developer. If you are looking to add secrets, please review the README.
+# We prefer instead to use Figaro (as configured in confg/application.yml)
 
 development:
-  secret_key_base: 605cc973cbd014024e52a6717d598b1f68f4b93fe97a7bc192a0f26ec11488eee2ef743bbc27c7c1ac3c6ab772028a043e013e708af6f43f3ebbc647162980cd
+  secret_key_base: <%= Figaro.env.secret_key_base %>
 
 test:
-  secret_key_base: 614f1abf100cb91a40426481cecea274b0df108b36c108bb44be636dbe781cd16de8acbe339697ea71084d4f6636f3459599cb0a2726be015b06921dae988273
-
-# Do not keep production secrets in the unencrypted secrets file.
-# Instead, either read values from the environment.
-# Or, use `bin/rails secrets:setup` to configure encrypted secrets
-# and move the `production:` environment over there.
-
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%= Figaro.env.secret_key_base %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,5 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/hydra-development
+  url: <%= Figaro.env.solr_url %>
 test:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
-production:
-  url: http://your.production.server:8080/bl_solr/core0
+  url: <%= Figaro.env.solr_url %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -3,3 +3,5 @@ development:
   url: <%= Figaro.env.solr_url %>
 test:
   url: <%= Figaro.env.solr_url %>
+staging:
+  url: <%= Figaro.env.solr_url %>

--- a/scripts/update_secrets.sh
+++ b/scripts/update_secrets.sh
@@ -16,6 +16,7 @@ git clone "git@git.library.nd.edu:$secret_repo"
 
 files_to_copy="
 	config/analytics.yml
+	config/application.yml
 	config/blacklight.yml
 	config/cable.yml
 	config/database.yml

--- a/scripts/update_secrets.sh
+++ b/scripts/update_secrets.sh
@@ -17,17 +17,7 @@ git clone "git@git.library.nd.edu:$secret_repo"
 files_to_copy="
 	config/analytics.yml
 	config/application.yml
-	config/blacklight.yml
-	config/cable.yml
-	config/database.yml
-	config/fcrepo_wrapper_test.yml
-	config/fedora.yml
-	config/redis.yml
 	config/role_map.yml
-	config/secrets.yml
-	config/solr.yml
-	config/solr_wrapper_test.yml
-	config/tinymce.yml
     "
 
 for f in $files_to_copy; do


### PR DESCRIPTION
## Adding Figaro

ed217db8d87965a6012d09fd1d83c11f443c0f5b

Command run:

```console
$ bundle
```

Discussion:

Figaro includes several features that are superior to the Rails secrets
mechanism:

* Consistency
  - Figaro uses ENV for configuration in every environment.
  - Secrets encourage using ENV for production only.
* Configuration File Structure
  - Figaro expects YAML containing key/value string pairs.
  - Secrets may contain nested structures with rich objects.
* Configuration Access
  - Figaro stores configuration values in ENV.
  - Rails stores configuration values in Rails.application.secrets.

And Figaro, through it's application initializer, can be configured to
raise an exception when specific ENV variables are not present during
application load.

The Figaro README contains ample discussion on why, see
https://github.com/laserlemon/figaro for more details

## Adding documentation about Figaro usage

4c1926607219f219aeaa9371c0a915e396644e0e


## Reworking secrets to leverage Figaro

78541b35c89bcab2e298b66631f5bba6c067441c

* Fixed a small typo concerning secrets
* Moved various configuration values into Figora administration
* Marked ENV variables that are required across all environments
  (see config/initializers/figaro_required_env_variables.rb)

As part of this change, I will also need to update the existing secrets
repository. At this time, however, we are working to get the application
up and running in a staging environment, so I'm holding on secrets
rework.

## Updating how we leverage Figaro

262fd7df78cff8f01793cca1117682eee1fdc89b

To reduce the cross-repository maintenance challenges, I'm reducing the
files that are copied. Instead relying on config/application.yml to
contain the majority of the configurable information.
