### PR TITLE
Add rack-mini profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'rack-mini-profiler'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,6 +509,8 @@ GEM
     rack (2.0.3)
     rack-cache (1.7.1)
       rack (>= 0.4)
+    rack-mini-profiler (0.10.7)
+      rack (>= 1.2.0)
     rack-protection (2.0.0)
       rack
     rack-test (0.8.2)
@@ -787,6 +789,7 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.7)
   rack-cache
+  rack-mini-profiler
   rails (~> 5.1.4)
   resque-pool
   rsolr (>= 1.0)

--- a/README.md
+++ b/README.md
@@ -67,10 +67,21 @@ Many upstream dependencies create their configurations to have a top-level key o
     $ bundle exec rake db:migrate
     ```
 
-7. Start the Fedora and SOLR server; This will download both as needed.
+7. Start the Fedora, SOLR, and Rails services; This will download Fedora and SOLR as needed.
 
     ```console
     $ bundle exec rake hydra:server
     ```
+    Optionally, you can separate the Fedora/Solr services from the rails service by adding:
+    ```console
+    $ SKIP_RAILS=true bundle exec rake hydra:server
+    ```
+    and in a different terminal:
+    ```console
+    $ bundle exec rails server
+    ```
+
 
 8. Open your favorite browser and go to http://localhost:3000
+
+9. To hit the rack miniprofiler go to http://localhost:3000/?pp=help, or click on the badge in the top left corner after rendering any page.


### PR DESCRIPTION
## Add rack-mini profiler

c39a38808adb1b2c7539d30ca89b28331b1a1b4a

- Added the gem and updated the Readme. Also added some optional instructions for separating the rails service from the background services. I've found this is helpful especially when using byebug breakpoints, since using the all in one hydra:server task breaks the shell from echoing what your typing if you don't separate it.