### PR TITLE
Dltp 1204 leverage cas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 gem 'capistrano-bundler'
 gem 'capistrano', '~> 3.5.0'
 gem 'coffee-rails', '~> 4.2'
+gem 'devise_cas_authenticatable'
 gem 'devise-guests', '~> 0.6'
 gem 'devise'
 gem 'figaro'

--- a/Gemfile
+++ b/Gemfile
@@ -5,49 +5,41 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-
-gem 'capistrano', '~> 3.5.0'
 gem 'capistrano-bundler'
+gem 'capistrano', '~> 3.5.0'
 gem 'coffee-rails', '~> 4.2'
+gem 'devise-guests', '~> 0.6'
+gem 'devise'
 gem 'figaro'
+gem 'hyrax', '2.0.0'
 gem 'jbuilder', '~> 2.5'
+gem 'jquery-rails'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
 gem 'rack-cache'
 gem 'rails', '~> 5.1.4'
 gem 'resque-pool'
+gem 'rsolr', '>= 1.0'
 gem 'sass-rails', '~> 5.0'
 gem 'turbolinks', '~> 5'
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
 
-group :development, :test do
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'capybara', '~> 2.13'
-  gem 'selenium-webdriver'
-end
-
 group :development do
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rack-mini-profiler'
-  gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring'
+  gem 'web-console', '>= 3.3.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem 'hyrax', '2.0.0'
 group :development, :test do
-  gem 'solr_wrapper', '>= 0.3'
-end
-
-gem 'rsolr', '>= 1.0'
-gem 'jquery-rails'
-gem 'devise'
-gem 'devise-guests', '~> 0.6'
-group :development, :test do
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'capybara', '~> 2.13'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'selenium-webdriver'
+  gem 'solr_wrapper', '>= 0.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,9 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.6.0)
       devise
+    devise_cas_authenticatable (1.10.3)
+      devise (>= 1.2.0)
+      rubycas-client (>= 2.2.1)
     diff-lcs (1.3)
     dropbox-sdk (1.6.5)
       json
@@ -649,6 +652,8 @@ GEM
       oauth2
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubycas-client (2.3.9)
+      activesupport
     rubyzip (1.2.1)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
@@ -780,6 +785,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   devise-guests (~> 0.6)
+  devise_cas_authenticatable
   fcrepo_wrapper
   figaro
   hyrax (= 2.0.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,17 +5,16 @@ class User < ApplicationRecord
   include Hyrax::User
   include Hyrax::UserUsageStats
 
-
-
   if Blacklight::Utils.needs_attr_accessible?
     attr_accessible :email, :password, :password_confirmation
   end
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+
+  # cas_authenticatable: CAS authentication support for Devise (https://github.com/nbudin/devise_cas_authenticatable)
+  # rememberable: manages generating and clearing a token for remembering the user from a saved cookie. (http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Models/Rememberable)
+  # trackable: tracks sign in count, timestamps and IP address. (http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Models/Trackable)
+  devise :cas_authenticatable, :rememberable, :trackable
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,8 @@ class User < ApplicationRecord
   def to_s
     email
   end
+
+  # @todo Implement cas_extra_attributes= against production type services
+  # @see https://github.com/nbudin/devise_cas_authenticatable#extra-attributes
+  def cas_extra_attributes=(extra_attributes); end
 end

--- a/config/application.yml
+++ b/config/application.yml
@@ -45,6 +45,10 @@ development:
   application_database_host: localhost
   blacklight_adapter: solr
   cable_adapter: async
+  cas_base_url: https://cas.library.nd.edu/cas
+  cas_validate_url: https://cas.library.nd.edu/cas/serviceValidate
+  cas_destination_url: "http://localhost:3000"
+  cas_follow_url: "http://localhost:3000"
   devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54
   fedora_base_path: /dev
   fedora_password: fedoraAdmin
@@ -60,6 +64,10 @@ test:
   application_database_host: localhost
   blacklight_adapter: solr
   cable_adapter: async
+  cas_base_url: https://cas.library.nd.edu/cas
+  cas_validate_url: https://cas.library.nd.edu/cas/serviceValidate
+  cas_destination_url: "http://localhost:3000"
+  cas_follow_url: "http://localhost:3000"
   devise_secret_key: b7adb179eac5f12b64c17a94f53a5819488ad2e190bbac281880501e0a5e3076548ad9a7e689680f333864242ee893eb986f870b432601ca3f52da6e6e435f54
   fedora_base_path: /dev
   fedora_password: fedoraAdmin

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,12 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+
+  config.cas_base_url = Figaro.env.cas_base_url!
+  config.cas_destination_url = Figaro.env.cas_destination_url if Figaro.env.cas_destination_url?
+  config.cas_validate_url = Figaro.env.cas_validate_url if Figaro.env.cas_validate_url?
+  config.cas_follow_url = Figaro.env.cas_follow_url if Figaro.env.cas_follow_url?
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/initializers/figaro_required_env_variables.rb
+++ b/config/initializers/figaro_required_env_variables.rb
@@ -12,6 +12,7 @@ Figaro.require_keys(
   'application_database_name',
   'blacklight_adapter',
   'cable_adapter',
+  'cas_base_url',
   'devise_secret_key',
   'fedora_base_path',
   'fedora_password',

--- a/db/migrate/20180110162655_update_user_for_cas_authentication.rb
+++ b/db/migrate/20180110162655_update_user_for_cas_authentication.rb
@@ -1,0 +1,10 @@
+class UpdateUserForCasAuthentication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :username, :string, null: false
+    add_index :users, :username, unique: true
+
+    remove_column :users, :encrypted_password
+    remove_column :users, :reset_password_token
+    remove_column :users, :reset_password_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201195157) do
+ActiveRecord::Schema.define(version: 20180110162655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -456,9 +456,6 @@ ActiveRecord::Schema.define(version: 20171201195157) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
@@ -492,8 +489,9 @@ ActiveRecord::Schema.define(version: 20171201195157) do
     t.binary "zotero_token"
     t.string "zotero_userid"
     t.string "preferred_locale"
+    t.string "username", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   create_table "version_committers", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Re-arranging gem declarations in Gemfile

0ff133831e11079b06d48c7a9a520fbd00201e4a

Instead of the mixed method, these are now alphabetized

## Adding devise_cas_authenticatable gem

1dc3258695b7adb994f797cdff6c3c865033b78c

Script ran:

```console
$ bundle
```

## Replacing database authentication with CAS auth

95ea6e9ec3134e1f49c9b2257110486fa29270db

Following https://github.com/nbudin/devise_cas_authenticatable README
on swapping database authentication for CAS authentication. This commit
does not include the configuration information.

## Updating users table for CAS authentication

8738142002629d07fcd5de1db5c3692495459fd5

Script ran:

```console
rails g migration UpdateUserForCasAuthentication
```

## Migrating database schema

98d94dcf05e228643bf4d8c47ceea8671f7f6e29

Script ran:

```console
$ bundle exec rake db:migrate
```

## Adding base configuration for local CAS option

1edf19d3547780075273babe91816edb03ccfd76

This has been verified by:

* Running `bundle exec rake hydra:server`
* Going to `http://localhost:3000`
* Then sign-in via Library's CAS
* And I'm then logged into the application
* Adding note concerning `#cas_extra_attributes=`; When we login to CAS,
  there are possible additional attributes that Curax can capture (e.g.
  email, name, etc.). It would be great to do that; However the current
  Library CAS does not expose that information.

DLTP-1218 #Close
Related to DLTP-1204
