### PR TITLE
Fix Curax CAS interaction for more than one user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   end
 
   # @todo Implement cas_extra_attributes= against production type services
+  # Based on tests there are no additional attributes returned via CAS
   # @see https://github.com/nbudin/devise_cas_authenticatable#extra-attributes
   def cas_extra_attributes=(extra_attributes); end
 end

--- a/db/migrate/20180116141522_remove_indexing_constraints.rb
+++ b/db/migrate/20180116141522_remove_indexing_constraints.rb
@@ -1,0 +1,5 @@
+class RemoveIndexingConstraints < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180110162655) do
+ActiveRecord::Schema.define(version: 20180116141522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -490,8 +490,7 @@ ActiveRecord::Schema.define(version: 20180110162655) do
     t.string "zotero_userid"
     t.string "preferred_locale"
     t.string "username", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
+    t.index ["username"], name: "index_users_on_username"
   end
 
   create_table "version_committers", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Removing unique users email constraint

f3d0a77a7e1c4e8c99c7325fcc401b87c2c6d519

```console
$ rails generate migration RemoveIndexingConstraints
```

Related to DLTP-1219

## Migrating database

63a79d1ccead585a410507a92597bd3817c8824d

```console
$ bundle exec rake db:migrate
```

## Removing logging of `User#cas_extra_attributes=`

f64d5113e1bc3a062f858b20d5345af327041520

Based on testing against test CAS, there are no additional attributes
provided. I'm leaving the method as a placeholder and reminder that
there could be information in the future.

It would be great to capture additional information from CAS and assign
that to the User record that is created. This is based on the
[`devise_cas_authenticatable` gem's documentation][documentation]

[documentation]:https://github.com/nbudin/devise_cas_authenticatable#extra-attributes
